### PR TITLE
fix: passes `requireAngular` global option to `generateContent`

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -18,5 +18,5 @@ export default function(content) {
         translations = extractTranslations(this, content, options),
         module = interpolateModule(this, translations, options);
 
-    return generateContent(module, locale, translations);
+    return generateContent(module, locale, translations, options.requireAngular);
 }


### PR DESCRIPTION
When I tried to use the `requireAngular` option from my `webpack.config.js` file I saw that the option wasn't applied, so the `requireAngular` was always set to `true`. When I check the code, I saw the `requireAngular` from `generateContent` was missing and it fixed the problem once set.